### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/Pedrock/strapi-provider-upload-backblaze-b2",
   "dependencies": {
-    "backblaze-b2": "1.3.1"
+    "backblaze-b2": "1.6.0"
   },
   "devDependencies": {
     "@types/node": "^11.13.4"


### PR DESCRIPTION
Update to backblaze-b2 version 1.6.0

With the 1.3.1 version, I got an erorr:
`error Error: Request failed with status code 401`

With version 1.6.0 it's ok!